### PR TITLE
Actualizar ruta relativa de las dependencias

### DIFF
--- a/EmpresaDeColectivo_Grupo3/nbproject/project.properties
+++ b/EmpresaDeColectivo_Grupo3/nbproject/project.properties
@@ -33,9 +33,13 @@ dist.javadoc.dir=${dist.dir}/javadoc
 dist.jlink.dir=${dist.dir}/jlink
 dist.jlink.output=${dist.jlink.dir}/EmpresaDeColectivo_Grupo3
 excludes=
+file.reference.jcalendar-1.4.zip=lib/jcalendar-1.4.zip
+file.reference.mariadb-java-client-3.1.4.jar=lib/mariadb-java-client-3.1.4.jar
 includes=**
 jar.compress=false
-javac.classpath=
+javac.classpath=\
+    ${file.reference.jcalendar-1.4.zip}:\
+    ${file.reference.mariadb-java-client-3.1.4.jar}
 # Space-separated list of extra javac options
 javac.compilerargs=
 javac.deprecation=false


### PR DESCRIPTION
Usar /EmpresaDeColectivo_Grupo3/lib/ como la carpeta principal de las dependencias para mantener rutas consistentes entre los desarrolladores